### PR TITLE
Add uncompress_to

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target/
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,11 @@ repository = "https://github.com/JeffBelgum/rust-snappy"
 documentation = "https://jeffbelgum.github.io/snappy/snappy/"
 homepage = "https://github.com/JeffBelgum/rust-snappy"
 description = "Rust bindings to the Google compression library 'snappy'"
+links = "snappy"
+build = "build.rs"
 
 [dependencies]
 libc = "0.2"
+
+[build-dependencies]
+pkg-config = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,12 @@
 [package]
-
 name = "snappy"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Daniel Micay <danielmicay@gmail.com>", "Jeff Belgum <jeffbelgum@gmail.com>"]
 license = "MIT"
 repository = "https://github.com/JeffBelgum/rust-snappy"
 documentation = "https://jeffbelgum.github.io/snappy/snappy/"
 homepage = "https://github.com/JeffBelgum/rust-snappy"
-description = """
-Rust bindings to the Google compression library, snappy.
-Explained in Rust Official Book: FFI section
-"""
+description = "Rust bindings to the Google compression library 'snappy'"
 
 [dependencies]
-libc = "0.1.7"
+libc = "0.2"

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 Snappy
-------------
+------
 
-[ Forked from https://github.com/thestinger/rust-snappy ]
+[![Build Status](https://travis-ci.org/JeffBelgum/rust-snappy.svg?branch=master)](https://travis-ci.org/JeffBelgum/rust-snappy) [![](http://meritbadge.herokuapp.com/snappy)](https://crates.io/crates/snappy)
 
-Snappy bindings for Rust as written in the [The Official Rust Book](https://doc.rust-lang.org/book/ffi.html)
+[ Originally forked from https://github.com/thestinger/rust-snappy ]
 
-It didn't exist on crates.io, and I needed to use it as a crate!
+Snappy bindings for Rust (as written in the [The Official Rust Book](https://doc.rust-lang.org/book/ffi.html).)
 
 [Documentation](https://jeffbelgum.github.io/snappy/snappy/)
 
@@ -29,4 +29,8 @@ Installing Snappy
 -----------------
 
 The Snappy C++ library can be installed on Mac OS X using homebrew ```brew
-install snappy```
+install snappy```.
+
+If that library is not installed in the usual path, you can export the
+`LD_LIBRARY_PATH` and `LD_RUN_PATH` environment variables before
+issueing `cargo build`.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add this to your `Cargo.toml`:
 
 ```ini
 [dependencies]
-snappy = "0.2.0"
+snappy = "0.3"
 ```
 
 and this to your crate root:

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,63 @@
+extern crate pkg_config;
+
+use std::fs;
+use std::path::Path;
+use std::env;
+
+fn main() {
+    configure_snappy();
+}
+
+fn configure_snappy() {
+    // try pkg_config first
+    if pkg_config::find_library("snappy").is_ok() {
+        return;
+    }
+
+    match env::var_os("SNAPPY_STATIC") {
+        Some(_) => {
+            println!("cargo:rustc-link-lib=static=snappy");
+            // From: https://github.com/alexcrichton/gcc-rs/blob/master/src/lib.rs
+            let target = env::var("TARGET").unwrap();
+            let cpp = if target.contains("darwin") {
+                "c++"
+            } else {
+                "stdc++"
+            };
+            println!("cargo:rustc-flags=-l {}", cpp);
+        },
+        None => {
+            println!("cargo:rustc-link-lib=dylib=snappy");
+        }
+    };
+
+    if let Some(path) = first_path_with_file("libsnappy.a") {
+        println!("cargo:rustc-link-search=native={}", path);
+    }
+}
+
+fn first_path_with_file(file: &str) -> Option<String> {
+    // we want to look in LD_LIBRARY_PATH and then some default folders
+    if let Some(ld_path) = env::var_os("LD_LIBRARY_PATH") {
+        for p in env::split_paths(&ld_path) {
+            if is_file_in(file, &p) {
+                return p.to_str().map(|s| String::from(s))
+            }
+        }
+    }
+    for p in vec!["/usr/lib","/usr/local/lib"] {
+        if is_file_in(file, &Path::new(p)) {
+            return Some(String::from(p))
+        }
+    }
+    return None
+}
+
+fn is_file_in(file: &str, folder: &Path) -> bool {
+    let full = folder.join(file);
+    match fs::metadata(full) {
+        Ok(ref found) if found.is_file() => true,
+        _ => false
+    }
+
+}


### PR DESCRIPTION
- Upgrade libc dependency
- Switch to `Result` instead of `Option` to force usage of the return types
- Add `uncompress_to` to allow buffer reuse
- Custom `build.rs` to support alternative snappy installations
