### PR TITLE
Adjust build

### DIFF
--- a/snappy-sys/Cargo.toml
+++ b/snappy-sys/Cargo.toml
@@ -13,4 +13,4 @@ libc = "0.2"
 
 [build-dependencies]
 pkg-config = "0.3.7"
-gcc = "0.3"
+cmake = "0.1"


### PR DESCRIPTION
This pr updates snappy to the latest version and use cmake to build the native library. Using config/make only works on *nix system, and cmake is also recommended by the upstream.
> CMake is supported and autotools will soon be deprecated.

Also can you turn on the issues tab? I want to raise an issue to discuss about whether to build and link to sources by default. But can't find any places to write it down.